### PR TITLE
Fix repeated loading clobbering <CR> map chain

### DIFF
--- a/plugin/matchem.vim
+++ b/plugin/matchem.vim
@@ -40,9 +40,10 @@
 "   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 " }}}
 
-if v:version < 700
+if exists('g:loaded_matchem') || v:version < 700
   finish
 endif
+let g:loaded_matchem = 1
 
 runtime plugin/delimitMate.vim
 if exists(':DelimitMate')


### PR DESCRIPTION
Matchem’s careful chaining of existing `<CR>` maps is clobbered by its own `s:Init()` function if the plugin is ever reloaded (which happens once in a while behind the scene when fiddling with `rtp` et al.). Though `s:Init()` could check the existing maps for the presence of its own function, the simpler solution seems to be a guard ensuring the plugin is only ever loaded once.
